### PR TITLE
Classpath value has to be enclosed in quotes to work properly

### DIFF
--- a/templates/default/etc/init.d/knotx.erb
+++ b/templates/default/etc/init.d/knotx.erb
@@ -33,7 +33,7 @@ start()
   -XX:+UseBiasedLocking \
   -XX:BiasedLockingStartupDelay=0 \
   -Dio.knotx.KnotxServer.options.config.httpPort=${KNOTX_PORT} \
-  -cp <%= @knotx_root_dir %>/app/\* io.knotx.launcher.LogbackLauncher \
+  -cp \"<%= @knotx_root_dir %>/app/*\" io.knotx.launcher.LogbackLauncher \
   ${KNOTX_JMX_OPTS} \
   ${KNOTX_DEBUG_OPTS} \
   ${KNOTX_GC_OPTS} \

--- a/templates/default/etc/systemd/system/knotx.service.erb
+++ b/templates/default/etc/systemd/system/knotx.service.erb
@@ -13,7 +13,7 @@ ExecStart=/bin/sh -c '/usr/bin/java \
   -XX:+UseBiasedLocking \
   -XX:BiasedLockingStartupDelay=0 \
   -Dio.knotx.KnotxServer.options.config.httpPort=${KNOTX_PORT} \
-  -cp <%= @knotx_root_dir %>/app/* io.knotx.launcher.LogbackLauncher \
+  -cp "<%= @knotx_root_dir %>/app/*" io.knotx.launcher.LogbackLauncher \
   ${KNOTX_JMX_OPTS} \
   ${KNOTX_DEBUG_OPTS} \
   ${KNOTX_GC_OPTS} \


### PR DESCRIPTION
knot.x won't detect modules correctly when quotes around classpath value are missing and at least 1 extension is present in `$KNOTX_HOME/app` directory