### PR TITLE
Validate knotx distribution structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,12 @@ cookbook!
 * `['knotx']['log_history']['knotx']` - maximum age (in days) for knot.x logs
 * `['knotx']['log_history']['access']` - maximum age (in days) for knot.x access
   log
-* `['knotx']['log_size']['knotx']` - maximum file size of knot.x log file 
+* `['knotx']['log_size']['knotx']` - maximum file size of knot.x log file
 * `['knotx']['log_size']['access']` - maximum file size of knot.x access log
   file
 * `['knotx']['release_url']` - base URL used to calculate download URL when
   only version was specified
-* `['knotx']['min_heap']` - `-Xms` JVM parameter (in MB) 
+* `['knotx']['min_heap']` - `-Xms` JVM parameter (in MB)
 * `['knotx']['max_heap']` - `-Xmx` JVM parameter (in MB)
 * `['knotx']['extra_opts']` - custom JVM parameters you'd like to add upon
   service start
@@ -113,7 +113,7 @@ Attributes from [java](https://supermarket.chef.io/cookbooks/java) cookbook
   calculate download URL)
 * `source` - full URL to knot.x ZIP distribution package. Overwrites `version`
 * `install_dir` - where knot.x instance should be deployed. If not set, knot.x
-  gets deployed to `['knotx']['base_dir']/id` directory 
+  gets deployed to `['knotx']['base_dir']/id` directory
 * `log_dir` - directory where all logs will be stored. If not set logs are
   written to `['knotx']['log_dir']/id` directory
 * `custom_logback` - `logback.xml` used to be delivered with ZIP distribution
@@ -189,6 +189,17 @@ knotx_instance 'Secondary knot.x instance' do
 end
 ```
 
+## Knot.x stack package
+Cookbook installs Knot.x instance that base on [knotx-stack](https://github.com/Knotx/knotx-stack)
+distribution. The structure of the package must keep following structure:
+```
+.
+└── ** (any folder name, e.g. `my-stack` or `knotx`)
+   ├── conf
+   └── lib
+```
+There should be only one top level folder (e.g. `my-stack` or `knotx`)
+
 # Work in progress
 
 ---
@@ -204,4 +215,3 @@ TODO:
 * jar cleanup after version switch
 * all actions including restart/start/stop
 * add extensions testing with multiple knotx instances
-

--- a/libraries/_resoruce_helpers.rb
+++ b/libraries/_resoruce_helpers.rb
@@ -108,7 +108,7 @@ module Knotx
     end
 
     def get_top_level_distro_directory(tmp_dir_path)
-      Dir.entries(tmp_dir_path).select {
+      Dir.entries(tmp_dir_path).find {
         |entry| File.directory? ::File.join(tmp_dir_path, entry) and !(entry == '.' || entry == '..')
       }
     end
@@ -124,7 +124,7 @@ module Knotx
     def validate_distro_structure(tmp_dir_path)
       Chef::Log.debug("Validating distro structure of: #{tmp_dir_path}")
       top_folder = get_top_level_distro_directory(tmp_dir_path)
-      if top_folder.size == 1
+      if top_folder != nil
         tmp_lib_path = ::File.join(tmp_dir_path, top_folder, 'lib')
         tmp_lib_exists = ::File.exist? tmp_lib_path
 
@@ -133,12 +133,12 @@ module Knotx
 
         if !(tmp_lib_exists && tmp_conf_exists)
           Chef::Application.fatal!(
-            "Expected `lib` and `conf` folders inside #{top_folder} not found!"
+            "Expected lib and conf folders inside #{top_folder} not found!"
           )
         end
       else
         Chef::Application.fatal!(
-          "Expected exactly one folder inside Knot.x distribution, found #{top_folder.size} (#{top_folder})"
+          "Expected exactly one folder inside Knot.x distribution: #{tmp_dir_path.size}"
         )
       end
     end

--- a/libraries/_resoruce_helpers.rb
+++ b/libraries/_resoruce_helpers.rb
@@ -107,6 +107,42 @@ module Knotx
       ::FileUtils.chown_R(node['knotx']['user'], node['knotx']['group'], dst)
     end
 
+    def get_top_level_distro_directory(tmp_dir_path)
+      Dir.entries(tmp_dir_path).select {
+        |entry| File.directory? ::File.join(tmp_dir_path, entry) and !(entry == '.' || entry == '..')
+      }
+    end
+
+    # Validates Knot.x stack distribution structure
+    # Expected one is:
+    # .
+    # └── ** (any folder name, e.g. `my-stack` or `knotx`)
+    #     ├── conf
+    #     └── lib
+    #
+    # If validation is successfull then returns top folder name
+    def validate_distro_structure(tmp_dir_path)
+      Chef::Log.debug("Validating distro structure of: #{tmp_dir_path}")
+      top_folder = get_top_level_distro_directory(tmp_dir_path)
+      if top_folder.size == 1
+        tmp_lib_path = ::File.join(tmp_dir_path, top_folder, 'lib')
+        tmp_lib_exists = ::File.exist? tmp_lib_path
+
+        tmp_conf_path = ::File.join(tmp_dir_path, top_folder, 'conf')
+        tmp_conf_exists = ::File.exist? tmp_conf_path
+
+        if !(tmp_lib_exists && tmp_conf_exists)
+          Chef::Application.fatal!(
+            "Expected `lib` and `conf` folders inside #{top_folder} not found!"
+          )
+        end
+      else
+        Chef::Application.fatal!(
+          "Expected exactly one folder inside Knot.x distribution, found #{top_folder.size} (#{top_folder})"
+        )
+      end
+    end
+
     def update_dist_checksum(checksum, dst_file)
       file = Chef::Resource::File.new(dst_file, run_context)
       file.content = checksum

--- a/libraries/provider_knotx_instance.rb
+++ b/libraries/provider_knotx_instance.rb
@@ -263,6 +263,8 @@ class Chef
             "#{new_resource.tmp_dir} directory..."
           )
           unzip(new_resource.download_path, new_resource.tmp_dir)
+          validate_distro_structure(new_resource.tmp_dir)
+          tmp_top_dir = get_top_level_distro_directory(new_resource.tmp_dir)
 
           # Get rid of exiting JAR and config files
           Chef::Log.debug(
@@ -274,20 +276,20 @@ class Chef
 
           # Move relevant parts to installation dir
           Chef::Log.debug(
-            "Copying #{::File.join(new_resource.tmp_dir, 'knotx', 'lib')} "\
+            "Copying #{::File.join(new_resource.tmp_dir, tmp_top_dir, 'lib')} "\
             "to #{new_resource.lib_dir}..."
           )
           cp_r(
-            ::File.join(new_resource.tmp_dir, 'knotx', 'lib', '.'),
+            ::File.join(new_resource.tmp_dir, tmp_top_dir, 'lib', '.'),
             new_resource.lib_dir
           )
 
           Chef::Log.debug(
-            "Copying #{::File.join(new_resource.tmp_dir, 'knotx', 'conf')} "\
+            "Copying #{::File.join(new_resource.tmp_dir, tmp_top_dir, 'conf')} "\
             "to #{new_resource.lib_dir}..."
           )
           cp_r(
-            ::File.join(new_resource.tmp_dir, 'knotx', 'conf', '.'),
+            ::File.join(new_resource.tmp_dir, tmp_top_dir, 'conf', '.'),
             new_resource.conf_dir
           )
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'karol.drazek@cognifide.com'
 license          'Apache-2.0'
 description      'Installs/Configures knotx'
 long_description 'Installs/Configures knotx'
-version          '0.5.0'
+version          '0.5.1'
 
 issues_url       'https://github.com/knotx/knotx-cookbook/issues'
 source_url       'https://github.com/Knotx/knotx-cookbook'


### PR DESCRIPTION
Structure of Knot.x Stack is validated now.
Additionally ZIP archive of stack can now have any name for the root level folder (before only `knotx` was valid).