### PR TITLE
Support for custom instance opts

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -24,8 +24,7 @@ platforms:
       require_chef_omnibus: <%= chef_version %>
     attributes:
       knotx:
-        # TODO: replace with proper URL after knot.x 1.3.0 release
-        url: 'https://oss.sonatype.org/content/repositories/snapshots/io/knotx/knotx-stack-manager/1.3.0-SNAPSHOT/knotx-stack-manager-1.3.0-20180425.065432-12.zip'
+        url: 'https://bintray.com/knotx/downloads/download_file?file_path=knotx-example-project-stack-1.4.0.zip'
       java:
         jdk:
           '8':

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ cookbook!
 * `['knotx']['debug_enabled']` - defines whether JVM debugging interface is
   enabled or not
 * `['knotx']['debug_port']` - port of JVM debug interface
+* `['knotx']['instance_opts']` - custom parameters you'd like to pass to [knotx command](https://github.com/Cognifide/knotx/blob/master/knotx-core/src/main/java/io/knotx/launcher/KnotxCommand.java)
 * `['knotx']['source']['knotx_init_cookbook']` - cookbook where SysVinit script
   is located
 * `['knotx']['source']['knotx_init_path']` path under `templates` where
@@ -151,6 +152,7 @@ The following attributes can be set this way:
 * `node['knotx'][ID]['jmx_port']`
 * `node['knotx'][ID]['debug_enabled']`
 * `node['knotx'][ID]['debug_port']`
+* `node['knotx'][ID]['instance_opts']`
 
 # Usage scenarios
 

--- a/attributes/commons.rb
+++ b/attributes/commons.rb
@@ -17,6 +17,6 @@
 # limitations under the License.
 
 # Java attributes
-default['java']['oracle']['accept_oracle_download_terms'] = 'true'
+default['java']['oracle']['accept_oracle_download_terms'] = true
 default['java']['jdk_version'] = '8'
 default['java']['install_flavor'] = 'oracle'

--- a/attributes/knotx.rb
+++ b/attributes/knotx.rb
@@ -54,6 +54,8 @@ default['knotx']['jmx_port'] = '18092'
 default['knotx']['debug_enabled'] = false
 default['knotx']['debug_port'] = '28092'
 
+default['knotx']['instance_opts'] = ''
+
 # TEMPLATE SOURCES
 default['knotx']['source']['knotx_init_cookbook'] = 'knotx'
 default['knotx']['source']['knotx_init_path'] = 'etc/init.d/knotx.erb'

--- a/libraries/_loader_helpers.rb
+++ b/libraries/_loader_helpers.rb
@@ -29,6 +29,7 @@ module Knotx
         jmx_port
         debug_enabled
         debug_port
+        instance_opts
       ).each do |var|
         if node['knotx'].key?(new_resource.id) &&
            node['knotx'][new_resource.id].key?(var)

--- a/libraries/_resoruce_helpers.rb
+++ b/libraries/_resoruce_helpers.rb
@@ -250,7 +250,8 @@ module Knotx
         jmx_ip:        new_resource.jmx_ip,
         jmx_port:      new_resource.jmx_port,
         debug_enabled: new_resource.debug_enabled,
-        debug_port:    new_resource.debug_port
+        debug_port:    new_resource.debug_port,
+        instance_opts: new_resource.instance_opts
       )
       template.run_action(:create)
 

--- a/libraries/resource_knotx_instance.rb
+++ b/libraries/resource_knotx_instance.rb
@@ -47,6 +47,7 @@ class Chef
       attr_accessor :jmx_port
       attr_accessor :debug_enabled
       attr_accessor :debug_port
+      attr_accessor :instance_opts
 
       # SOURCE opts
       attr_accessor :knotx_init_cookbook
@@ -68,7 +69,7 @@ class Chef
         @action = :install
 
         @id = name
-        @version = '1.2.1'
+        @version = '1.4.0'
         @source = nil
         @install_dir = nil
         @log_dir = nil

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'karol.drazek@cognifide.com'
 license          'Apache-2.0'
 description      'Installs/Configures knotx'
 long_description 'Installs/Configures knotx'
-version          '0.5.1'
+version          '0.6.0'
 
 issues_url       'https://github.com/knotx/knotx-cookbook/issues'
 source_url       'https://github.com/Knotx/knotx-cookbook'

--- a/recipes/_install.rb
+++ b/recipes/_install.rb
@@ -30,6 +30,7 @@ node.default['knotx']['secondary']['extra_opts'] = '-Dknotx.port=8093'
 node.default['knotx']['secondary']['jmx_port'] = '18093'
 node.default['knotx']['secondary']['debug_enabled'] = true
 node.default['knotx']['secondary']['debug_port'] = '28093'
+node.default['knotx']['secondary']['instance_opts'] = '-conf /opt/knotx/secondary/conf/bootstrap.json'
 
 knotx_instance 'Secondary knot.x instance' do
   id 'secondary'

--- a/templates/default/etc/init.d/knotx.erb
+++ b/templates/default/etc/init.d/knotx.erb
@@ -40,7 +40,7 @@ start()
   -Dvertx.cli.usage.prefix=knotx \
   -classpath '<%= @conf_dir %>:<%= ::File.join(@lib_dir, '*') %>' \
   ${KNOTX_EXTRA_OPTS} \
-  io.vertx.core.Launcher run-knotx ${KNOTX_INSTNCE_OPTS} \
+  io.vertx.core.Launcher run-knotx ${$KNOTX_INSTANCE_OPTS} \
   >> <%= ::File.join(@log_dir, 'start.log') %> 2>&1 &" && echo_success || echo_failure
   RETVAL=$?
   echo

--- a/templates/default/etc/init.d/knotx.erb
+++ b/templates/default/etc/init.d/knotx.erb
@@ -40,7 +40,7 @@ start()
   -Dvertx.cli.usage.prefix=knotx \
   -classpath '<%= @conf_dir %>:<%= ::File.join(@lib_dir, '*') %>' \
   ${KNOTX_EXTRA_OPTS} \
-  io.vertx.core.Launcher run-knotx \
+  io.vertx.core.Launcher run-knotx ${KNOTX_INSTNCE_OPTS} \
   >> <%= ::File.join(@log_dir, 'start.log') %> 2>&1 &" && echo_success || echo_failure
   RETVAL=$?
   echo

--- a/templates/default/etc/systemd/system/knotx.service.erb
+++ b/templates/default/etc/systemd/system/knotx.service.erb
@@ -20,7 +20,7 @@ ExecStart=<%= @java_home %>/bin/java \
   -Dvertx.cli.usage.prefix=knotx \
   -classpath '<%= @conf_dir %>:<%= ::File.join(@lib_dir, '*') %>' \
   $KNOTX_EXTRA_OPTS \
-  io.vertx.core.Launcher run-knotx
+  io.vertx.core.Launcher run-knotx ${KNOTX_INSTNCE_OPTS}
 Type=simple
 PIDFile=/var/run/<%= @id %>
 User=<%= @user %>

--- a/templates/default/etc/systemd/system/knotx.service.erb
+++ b/templates/default/etc/systemd/system/knotx.service.erb
@@ -20,7 +20,7 @@ ExecStart=<%= @java_home %>/bin/java \
   -Dvertx.cli.usage.prefix=knotx \
   -classpath '<%= @conf_dir %>:<%= ::File.join(@lib_dir, '*') %>' \
   $KNOTX_EXTRA_OPTS \
-  io.vertx.core.Launcher run-knotx ${KNOTX_INSTNCE_OPTS}
+  io.vertx.core.Launcher run-knotx $KNOTX_INSTANCE_OPTS
 Type=simple
 PIDFile=/var/run/<%= @id %>
 User=<%= @user %>

--- a/templates/default/knotx/knotx.conf.erb
+++ b/templates/default/knotx/knotx.conf.erb
@@ -23,4 +23,4 @@ KNOTX_JMX_OPTS="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.po
 KNOTX_DEBUG_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=<%= @debug_port %>"
 <%- end -%>
 
-KNOTX_INSTNCE_OPTS="<%= @instance_opts %>"
+KNOTX_INSTANCE_OPTS="<%= @instance_opts %>"

--- a/templates/default/knotx/knotx.conf.erb
+++ b/templates/default/knotx/knotx.conf.erb
@@ -22,3 +22,5 @@ KNOTX_JMX_OPTS="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.po
 <%- if @debug_enabled == true -%>
 KNOTX_DEBUG_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=<%= @debug_port %>"
 <%- end -%>
+
+KNOTX_INSTNCE_OPTS="<%= @instance_opts %>"


### PR DESCRIPTION
Support for custom instance opts.
Update to use Knot.x `1.4.0`
Fixed `.kitchen` and default properties for java.

Temporary target is `feature/validate-knotx-distribution-structure`, when #18 will be merged, I will change the target to `master`.