### PR TITLE
Fix double Knot.x logs.

### DIFF
--- a/templates/default/knotx/logback.xml.erb
+++ b/templates/default/knotx/logback.xml.erb
@@ -35,7 +35,7 @@
         <appender-ref ref="FILE" />
     </root>
 
-    <logger name="io.knotx" level="<%= @knotx_log_level %>">
+    <logger name="io.knotx" level="<%= @knotx_log_level %>" additivity="false">
         <appender-ref ref="FILE" />
     </logger>
 </configuration>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix double log entries for Knot.x classes.

## Description
<!--- Describe your changes in detail -->
"additivity" flag has been set to "false" for logger "io.knotx" (default "true") 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Double log entries appeared for Knot.x classes.

## Screenshots (if appropriate)

## Upgrade notes (if appropriate)
<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->
No changes needed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
