### PR TITLE
Enable custom logback config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# knotx-cookbook changefile
+
+## 0.4.1
+- Created from [v0.4.0](https://github.com/Knotx/knotx-cookbook/tree/v0.4.0)
+- [PR-26](https://github.com/Knotx/knotx-cookbook/pull/26) - Enable custom logback configuration with `default['knotx']['config']['git_enabled'] = true`

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Cookbook that installs and knotx instance.
     <td><tt>default['knotx']['config']['git_enabled']</tt></td>
     <td>String</td>
     <td>
-      If true, then configuration is pulled from git to 'config' directory residing in instance directory
+      If true, then Knot.x configuration and logback configs is pulled from git to 'config' directory residing in instance directory
     </td>
     <td><tt>false</tt></td>
   </tr>

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'karol.drazek@cognifide.com'
 license          'apachev2'
 description      'Installs/Configures knotx'
 long_description 'Installs/Configures knotx'
-version          '0.4.0'
+version          '0.4.1'
 
 issues_url       'https://github.com/knotx/knotx-cookbook/issues'
 source_url       'https://github.com/Knotx/knotx-cookbook'


### PR DESCRIPTION
## Description
Enable custom logback configuration with `default['knotx']['config']['git_enabled'] = true`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
